### PR TITLE
feat: implementar classe EnvironmentSensor para DHT11

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,20 @@ void loop() {
 
 ### 3) O que a classe faz
 - `EnvironmentSensor::EnvData` tem `temperature`, `humidity` e `valid`.
-- `readData()` usa `isnan()` para detectar falhas de leitura.
-- Se houver falha, `valid = false` e um erro é impresso no Serial.
+- `readData()` garante leitura DHT11 no mínimo a cada 2000ms (não bloqueante).
+- Se houver `NaN`, o sensor é reinicializado suavemente e `valid` é `false`.
+- Implementa verificação de sanidade para saltos impossíveis de temperatura/umidade.
+- Logs de depuração são emitidos no Serial (`Lendo DHT11...`, `Aguardando intervalo...`, `Erro de sanidade...`).
 
-### 4) Dependências PlatformIO
+### 4) Build / dependências
+No `platformio.ini`:
+```ini
+lib_deps =
+  bblanchon/ArduinoJson @ ^7.0.0
+  adafruit/DHT sensor library @ ^1.4.6
+  adafruit/Adafruit Unified Sensor @ ^1.1.14
+```
+
 No `platformio.ini`:
 ```ini
 lib_deps =

--- a/README.md
+++ b/README.md
@@ -13,3 +13,52 @@ A branch `main` está **bloqueada** para commits diretos.
 
 ---
 **Stack:** C++, PlatformIO, ESP32.
+
+## 📘 Exemplo de uso: EnvironmentSensor (DHT11)
+
+### 1) Conectar DHT11
+- DHT11 Data -> GPIO4
+- VCC -> 3.3V
+- GND -> GND
+
+### 2) Exemplo de código
+```cpp
+#include <Arduino.h>
+#include "EnvironmentSensor.h"
+
+EnvironmentSensor envSensor(4, DHT11);
+
+void setup() {
+  Serial.begin(115200);
+  envSensor.begin();
+}
+
+void loop() {
+  EnvironmentSensor::EnvData data = envSensor.readData();
+  if (data.valid) {
+    Serial.print("Temperatura: ");
+    Serial.print(data.temperature, 1);
+    Serial.print(" C, Umidade: ");
+    Serial.print(data.humidity, 1);
+    Serial.println(" %");
+  } else {
+    Serial.println("Leitura inválida do DHT11.");
+  }
+  delay(2000); // Em produção, prefira millis() para código não bloqueante.
+}
+```
+
+### 3) O que a classe faz
+- `EnvironmentSensor::EnvData` tem `temperature`, `humidity` e `valid`.
+- `readData()` usa `isnan()` para detectar falhas de leitura.
+- Se houver falha, `valid = false` e um erro é impresso no Serial.
+
+### 4) Dependências PlatformIO
+No `platformio.ini`:
+```ini
+lib_deps =
+  bblanchon/ArduinoJson @ ^7.0.0
+  adafruit/DHT sensor library @ ^1.4.6
+  adafruit/Adafruit Unified Sensor @ ^1.1.14
+```
+

--- a/include/EnvironmentSensor.h
+++ b/include/EnvironmentSensor.h
@@ -1,0 +1,31 @@
+#ifndef ENVIRONMENT_SENSOR_H
+#define ENVIRONMENT_SENSOR_H
+
+#include <Arduino.h>
+#include <DHT.h>
+
+class EnvironmentSensor {
+public:
+  // Estrutura de dados para retornar leitura de temperatura e umidade.
+  struct EnvData {
+    float temperature; // Temperatura em graus Celsius
+    float humidity;    // Umidade relativa em porcentagem
+    bool valid;        // Indica se a leitura foi válida
+  };
+
+  // Cria um sensor DHT11 no pino informado.
+  EnvironmentSensor(uint8_t dhtPin = 4, uint8_t dhtType = DHT11);
+
+  // Inicializa o sensor (deve ser chamado no setup).
+  void begin();
+
+  // Lê os dados do sensor e devolve EnvData contendo valid.
+  EnvData readData();
+
+private:
+  DHT _dht;
+  uint8_t _pin;
+  uint8_t _type;
+};
+
+#endif // ENVIRONMENT_SENSOR_H

--- a/include/EnvironmentSensor.h
+++ b/include/EnvironmentSensor.h
@@ -26,6 +26,10 @@ private:
   DHT _dht;
   uint8_t _pin;
   uint8_t _type;
+  unsigned long _lastReadTime;
+  EnvData _lastData;
+  bool _hasLastValid;
+  bool isSanityOk(float temperature, float humidity) const;
 };
 
 #endif // ENVIRONMENT_SENSOR_H

--- a/src/EnvironmentSensor.cpp
+++ b/src/EnvironmentSensor.cpp
@@ -1,28 +1,73 @@
 #include "EnvironmentSensor.h"
 
 EnvironmentSensor::EnvironmentSensor(uint8_t dhtPin, uint8_t dhtType)
-    : _dht(dhtPin, dhtType), _pin(dhtPin), _type(dhtType) {
+    : _dht(dhtPin, dhtType), _pin(dhtPin), _type(dhtType), _lastReadTime(0), _hasLastValid(false) {
+  _lastData.temperature = NAN;
+  _lastData.humidity = NAN;
+  _lastData.valid = false;
 }
 
 void EnvironmentSensor::begin() {
   _dht.begin();
 }
 
-EnvironmentSensor::EnvData EnvironmentSensor::readData() {
-  EnvironmentSensor::EnvData data;
-
-  // Leitura de temperatura e umidade do DHT11
-  data.temperature = _dht.readTemperature();
-  data.humidity = _dht.readHumidity();
-  data.valid = true;
-
-  // Tratamento de erros com isnan()
-  if (isnan(data.temperature) || isnan(data.humidity)) {
-    data.valid = false;
-    Serial.println("ERRO: Falha na leitura do DHT11. Verifique conexão e alimentação do sensor.");
-    data.temperature = NAN;
-    data.humidity = NAN;
+bool EnvironmentSensor::isSanityOk(float temperature, float humidity) const {
+  if (!_hasLastValid) {
+    return true;
   }
 
-  return data;
+  // Regras conservadoras de salto impossível.
+  const float maxTempDelta = 20.0; // variação máxima aceitável em 2s
+  const float maxHumidityDelta = 30.0; // variação máxima aceitável em 2s
+
+  if (fabs(temperature - _lastData.temperature) > maxTempDelta) {
+    return false;
+  }
+  if (fabs(humidity - _lastData.humidity) > maxHumidityDelta) {
+    return false;
+  }
+  return true;
+}
+
+EnvironmentSensor::EnvData EnvironmentSensor::readData() {
+  unsigned long now = millis();
+
+  // Requisito DHT11: não ler mais de 1x a cada 2 segundos.
+  if (now - _lastReadTime < 2000 && _lastData.valid) {
+    Serial.println("Aguardando intervalo do sensor DHT11 (2000ms)... Retornando última leitura válida.");
+    return _lastData;
+  }
+
+  Serial.println("Lendo DHT11...");
+  float temp = _dht.readTemperature();
+  float hum = _dht.readHumidity();
+  _lastReadTime = now;
+
+  if (isnan(temp) || isnan(hum)) {
+    Serial.println("Erro de leitura: valor NaN detectado. Reinicializando sensor...");
+    _dht.begin();
+    _lastData.valid = false;
+    _lastData.temperature = NAN;
+    _lastData.humidity = NAN;
+    return _lastData;
+  }
+
+  if (!isSanityOk(temp, hum)) {
+    Serial.println("Erro de sanidade: salto de leitura muito grande. Descartando leitura.");
+    // Mantém última leitura válida e retorna ela para estabilidade.
+    return _lastData;
+  }
+
+  _lastData.temperature = temp;
+  _lastData.humidity = hum;
+  _lastData.valid = true;
+  _hasLastValid = true;
+
+  Serial.print("Sucesso: Temp=");
+  Serial.print(temp, 1);
+  Serial.print(" C, Umid=");
+  Serial.print(hum, 1);
+  Serial.println(" %");
+
+  return _lastData;
 }

--- a/src/EnvironmentSensor.cpp
+++ b/src/EnvironmentSensor.cpp
@@ -1,0 +1,28 @@
+#include "EnvironmentSensor.h"
+
+EnvironmentSensor::EnvironmentSensor(uint8_t dhtPin, uint8_t dhtType)
+    : _dht(dhtPin, dhtType), _pin(dhtPin), _type(dhtType) {
+}
+
+void EnvironmentSensor::begin() {
+  _dht.begin();
+}
+
+EnvironmentSensor::EnvData EnvironmentSensor::readData() {
+  EnvironmentSensor::EnvData data;
+
+  // Leitura de temperatura e umidade do DHT11
+  data.temperature = _dht.readTemperature();
+  data.humidity = _dht.readHumidity();
+  data.valid = true;
+
+  // Tratamento de erros com isnan()
+  if (isnan(data.temperature) || isnan(data.humidity)) {
+    data.valid = false;
+    Serial.println("ERRO: Falha na leitura do DHT11. Verifique conexão e alimentação do sensor.");
+    data.temperature = NAN;
+    data.humidity = NAN;
+  }
+
+  return data;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,44 +1,46 @@
 #include <Arduino.h>
+#include "EnvironmentSensor.h"
 
 #define LED_PIN 2
 
 // Variáveis para controlar o tempo sem travar
 unsigned long previousMillis = 0;  // Guarda o último momento que o LED piscou
-const long interval = 1000;        // Intervalo desejado (1000ms = 1 segundo)
+const long interval = 2000;        // Intervalo desejado (2000ms = 2 segundos)
 
 // Estado atual do LED
 int ledState = LOW;
 
+// Sensor DHT11 no GPIO4
+EnvironmentSensor environmentSensor(4, DHT11);
+
 void setup() {
   Serial.begin(115200);
   pinMode(LED_PIN, OUTPUT);
+  environmentSensor.begin();
   Serial.println("AgroSense Node-Six: Boot Inicializado! 🚀");
 }
 
 void loop() {
-  // 1. Pega o tempo atual da máquina
   unsigned long currentMillis = millis();
 
-  // 2. Pergunta: "Já passou 1 segundo desde a última vez?"
+  // Pisca LED sem bloquear
   if (currentMillis - previousMillis >= interval) {
-    // Sim, passou! Salva o tempo atual para a próxima contagem
     previousMillis = currentMillis;
-
-    // Troca o estado do LED (Se tá ligado, desliga. Se tá desligado, liga)
-    if (ledState == LOW) {
-      ledState = HIGH;
-      Serial.println("Status: Aguardando sensores... (LED ON)");
-    } else {
-      ledState = LOW;
-      Serial.println("Status: Aguardando sensores... (LED OFF)");
-    }
-
-    // Aplica a mudança no pino físico
+    ledState = (ledState == LOW ? HIGH : LOW);
     digitalWrite(LED_PIN, ledState);
-  }
+    Serial.print("LED ");
+    Serial.println(ledState == HIGH ? "ON" : "OFF");
 
-  // --- ÁREA LIVRE ---
-  // Aqui você pode colocar código para ler sensores ou verificar Wi-Fi.
-  // O processador vai passar por aqui milhares de vezes por segundo
-  // enquanto o "if" lá de cima não for verdadeiro.
+    // Lê dados do sensor ambiente
+    EnvironmentSensor::EnvData reading = environmentSensor.readData();
+    if (reading.valid) {
+      Serial.print("Temperatura: ");
+      Serial.print(reading.temperature, 1);
+      Serial.print(" C, Umidade: ");
+      Serial.print(reading.humidity, 1);
+      Serial.println(" %");
+    } else {
+      Serial.println("Leitura ambiente inválida.");
+    }
+  }
 }


### PR DESCRIPTION
### Adicionada uma interface EnvironmentSensor reutilizável para sensores DHT e integrada ao firmware de exemplo. 

Arquivos adicionados:
 - include/EnvironmentSensor.h e src/EnvironmentSensor.cpp implementam a interface EnvironmentSensor com EnvData, begin(), readData() e tratamento de erros baseado em isnan()/NAN. src/main.cpp atualizado para instanciar e inicializar o sensor (GPIO4, DHT11), ler e registrar temperatura/umidade no loop não bloqueante e alterar o intervalo de intermitência do LED de 1000ms para 2000ms. 
- README.md atualizado com diagrama de fiação, exemplo de uso, notas sobre o comportamento e dependências da biblioteca PlatformIO.

----

### Adicionada limitação de taxa, cache e validação de sanidade para leituras do sensor DHT11.

Alterações:
- README.md: documenta o comportamento (intervalo de leitura não bloqueante de 2000 ms, tratamento de NaN, verificações de sanidade, logs de depuração) e adiciona dependências da biblioteca PlatformIO.

- include/EnvironmentSensor.h: adiciona as declarações _lastReadTime, _lastData, _hasLastValid e isSanityOk().
- src/EnvironmentSensor.cpp: implementa o cache da última leitura, impõe um intervalo mínimo de 2000 ms, detecta NaN e reinicializa o sensor suavemente, aplica limites de sanidade conservadores para saltos impossíveis, emite logs de depuração serial e atualiza a última leitura válida armazenada.

Objetivo: prevenir leituras frequentes/errôneas do DHT11, melhorar a estabilidade retornando os últimos dados válidos quando apropriado e fornecer informações de depuração mais claras.

---