### PR TITLE
Feat: Implementação robusta do WIFI e implementação do portal cautivo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,24 +65,25 @@ lib_deps =
 ```
 
 ### 5) Wi-Fi implementado
-O `src/main.cpp` agora inclui uma camada básica de conexão Wi-Fi para ESP32 com:
-- modo Station (`WiFi.mode(WIFI_STA)`)
-- reconexão automática em caso de queda
-- limite de tentativas (`WIFI_MAX_RECONNECT_ATTEMPTS`)
-- backoff entre tentativas (`WIFI_RECONNECT_BACKOFF_MS`)
-- logs detalhados no `Serial Monitor`
-- eventos do sistema via `WiFi.onEvent()`
+O firmware agora inclui um `WiFiManager` com captive portal para ESP32.
+O dispositivo tenta conectar automaticamente com as credenciais armazenadas e, se falhar ou se não houver configuração, inicia um ponto de acesso chamado `AgroSense-Setup`.
+
+Funcionalidades:
+- conexão em modo Station quando credenciais estão salvas
+- reconexão automática com limite de tentativas
+- backoff entre tentativas para não travar o loop
+- portal cautivo com DNS redirecionando para a página de configuração
+- formulário para informar SSID, senha e token do usuário
+- persistência via NVS/Preferences para salvar credenciais e token
 
 Para testar:
-1. Atualize `src/main.cpp` com seu `WIFI_SSID` e `WIFI_PASSWORD`.
-2. Compile e faça upload para o ESP32.
-3. Abra o Serial Monitor em `115200`.
-4. Observe as mensagens:
-   - `Station iniciado.`
-   - `Conectado ao AP.`
-   - `IP obtido:`
-   - `Desconectado do AP.`
-   - `Tentativa de reconexão X/Y...`
+1. Compile e faça upload para o ESP32.
+2. Abra o Serial Monitor em `115200`.
+3. Se o dispositivo não tiver credenciais válidas ou não conseguir se conectar, o AP `AgroSense-Setup` será iniciado.
+4. Conecte um celular ou notebook em `AgroSense-Setup`.
+5. Abra qualquer endereço no navegador; você será redirecionado para o portal.
+6. Preencha o SSID, a senha da sua rede e, opcionalmente, o token do usuário.
+7. Salve; o dispositivo reiniciará e tentará se conectar à rede configurada.
 
-Se quiser testar falha de conexão, desconecte o roteador ou altere a senha e veja o ESP32 reconectar automaticamente.
+Para validar o funcionamento do captive portal, desconecte o roteador ou configure uma senha errada e observe o ESP32 abrir novamente o AP de configuração.
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,25 @@ lib_deps =
   adafruit/Adafruit Unified Sensor @ ^1.1.14
 ```
 
-No `platformio.ini`:
-```ini
-lib_deps =
-  bblanchon/ArduinoJson @ ^7.0.0
-  adafruit/DHT sensor library @ ^1.4.6
-  adafruit/Adafruit Unified Sensor @ ^1.1.14
-```
+### 5) Wi-Fi implementado
+O `src/main.cpp` agora inclui uma camada básica de conexão Wi-Fi para ESP32 com:
+- modo Station (`WiFi.mode(WIFI_STA)`)
+- reconexão automática em caso de queda
+- limite de tentativas (`WIFI_MAX_RECONNECT_ATTEMPTS`)
+- backoff entre tentativas (`WIFI_RECONNECT_BACKOFF_MS`)
+- logs detalhados no `Serial Monitor`
+- eventos do sistema via `WiFi.onEvent()`
+
+Para testar:
+1. Atualize `src/main.cpp` com seu `WIFI_SSID` e `WIFI_PASSWORD`.
+2. Compile e faça upload para o ESP32.
+3. Abra o Serial Monitor em `115200`.
+4. Observe as mensagens:
+   - `Station iniciado.`
+   - `Conectado ao AP.`
+   - `IP obtido:`
+   - `Desconectado do AP.`
+   - `Tentativa de reconexão X/Y...`
+
+Se quiser testar falha de conexão, desconecte o roteador ou altere a senha e veja o ESP32 reconectar automaticamente.
 

--- a/include/WiFiManager.h
+++ b/include/WiFiManager.h
@@ -1,0 +1,63 @@
+#ifndef WIFI_MANAGER_H
+#define WIFI_MANAGER_H
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <WebServer.h>
+#include <DNSServer.h>
+#include <Preferences.h>
+
+class WiFiManager {
+public:
+  struct Config {
+    String ssid;
+    String password;
+    String userToken;
+
+    bool isValid() const {
+      return ssid.length() > 0 && password.length() > 0;
+    }
+  };
+
+  WiFiManager(uint8_t maxReconnectAttempts = 5,
+              unsigned long reconnectBackoffMs = 5000UL,
+              unsigned long reconnectResetMs = 60000UL);
+
+  void begin();
+  void loop();
+  bool isConnected() const;
+  bool portalActive() const;
+  const Config& getConfig() const;
+
+private:
+  static WiFiManager* _instance;
+  static void onWiFiEventStatic(WiFiEvent_t event);
+
+  void onWiFiEvent(WiFiEvent_t event);
+  void loadConfig();
+  void saveConfig(const String& ssid, const String& password, const String& userToken);
+  void startStation();
+  void attemptReconnect();
+  void startCaptivePortal();
+  void stopCaptivePortal();
+  String captivePortalPage(const String& message = String()) const;
+  void handleRoot();
+  void handleSave();
+  void handleNotFound();
+
+  Config _config;
+  Preferences _preferences;
+  WebServer _server;
+  DNSServer _dnsServer;
+  bool _connected;
+  bool _portalStarted;
+  bool _reconnectPending;
+  uint8_t _reconnectAttempts;
+  unsigned long _lastActionMillis;
+  unsigned long _lastStatusMillis;
+  const uint8_t _maxReconnect;
+  const unsigned long _reconnectBackoffMs;
+  const unsigned long _reconnectResetMs;
+};
+
+#endif // WIFI_MANAGER_H

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -1,0 +1,264 @@
+#include "WiFiManager.h"
+
+WiFiManager* WiFiManager::_instance = nullptr;
+
+WiFiManager::WiFiManager(uint8_t maxReconnectAttempts,
+                         unsigned long reconnectBackoffMs,
+                         unsigned long reconnectResetMs)
+    : _server(80),
+      _connected(false),
+      _portalStarted(false),
+      _reconnectPending(false),
+      _reconnectAttempts(0),
+      _lastActionMillis(0),
+      _lastStatusMillis(0),
+      _maxReconnect(maxReconnectAttempts),
+      _reconnectBackoffMs(reconnectBackoffMs),
+      _reconnectResetMs(reconnectResetMs) {
+  _instance = this;
+}
+
+void WiFiManager::begin() {
+  loadConfig();
+  WiFi.onEvent(onWiFiEventStatic);
+
+  _server.on("/", HTTP_GET, [this]() { handleRoot(); });
+  _server.on("/save", HTTP_POST, [this]() { handleSave(); });
+  _server.onNotFound([this]() { handleNotFound(); });
+
+  if (_config.isValid()) {
+    startStation();
+  } else {
+    Serial.println("[WiFiManager] Nenhuma configuração de Wi-Fi encontrada. Iniciando portal cautivo.");
+    startCaptivePortal();
+  }
+}
+
+void WiFiManager::loop() {
+  if (_portalStarted) {
+    _dnsServer.processNextRequest();
+    _server.handleClient();
+    return;
+  }
+
+  unsigned long now = millis();
+  if (_reconnectPending) {
+    attemptReconnect();
+  }
+
+  if (now - _lastStatusMillis >= 5000UL) {
+    _lastStatusMillis = now;
+    wl_status_t status = WiFi.status();
+    Serial.printf("[WiFiManager] Wi-Fi status: %d (%s)\n", status,
+                  status == WL_CONNECTED ? "CONNECTED" : "DISCONNECTED");
+    if (status == WL_CONNECTED) {
+      Serial.printf("[WiFiManager] IP: %s\n", WiFi.localIP().toString().c_str());
+      Serial.printf("[WiFiManager] SSID: %s\n", WiFi.SSID().c_str());
+      Serial.printf("[WiFiManager] RSSI: %d dBm\n", WiFi.RSSI());
+    }
+  }
+}
+
+bool WiFiManager::isConnected() const {
+  return _connected && WiFi.status() == WL_CONNECTED;
+}
+
+bool WiFiManager::portalActive() const {
+  return _portalStarted;
+}
+
+const WiFiManager::Config& WiFiManager::getConfig() const {
+  return _config;
+}
+
+void WiFiManager::onWiFiEventStatic(WiFiEvent_t event) {
+  if (_instance) {
+    _instance->onWiFiEvent(event);
+  }
+}
+
+void WiFiManager::onWiFiEvent(WiFiEvent_t event) {
+  switch (event) {
+    case SYSTEM_EVENT_STA_START:
+      Serial.println("[WiFiManager] STA iniciado.");
+      break;
+    case SYSTEM_EVENT_STA_CONNECTED:
+      Serial.println("[WiFiManager] Conectado ao AP.");
+      break;
+    case SYSTEM_EVENT_STA_GOT_IP:
+      _connected = true;
+      _reconnectAttempts = 0;
+      _reconnectPending = false;
+      Serial.printf("[WiFiManager] IP obtido: %s\n", WiFi.localIP().toString().c_str());
+      break;
+    case SYSTEM_EVENT_STA_DISCONNECTED:
+      _connected = false;
+      _reconnectPending = true;
+      Serial.printf("[WiFiManager] Desconectado do AP. Tentativas: %u/%u\n",
+                    _reconnectAttempts, _maxReconnect);
+      break;
+    default:
+      Serial.printf("[WiFiManager] Evento Wi-Fi: %u\n", event);
+      break;
+  }
+}
+
+void WiFiManager::loadConfig() {
+  _preferences.begin("agrosense", true);
+  _config.ssid = _preferences.getString("ssid", "");
+  _config.password = _preferences.getString("password", "");
+  _config.userToken = _preferences.getString("token", "");
+  _preferences.end();
+
+  if (_config.isValid()) {
+    Serial.println("[WiFiManager] Configuração de Wi-Fi carregada.");
+    Serial.printf("[WiFiManager] SSID salvo: %s\n", _config.ssid.c_str());
+    if (_config.userToken.length() > 0) {
+      Serial.printf("[WiFiManager] Token de usuário carregado: %s\n", _config.userToken.c_str());
+    }
+  }
+}
+
+void WiFiManager::saveConfig(const String& ssid,
+                             const String& password,
+                             const String& userToken) {
+  _preferences.begin("agrosense", false);
+  _preferences.putString("ssid", ssid);
+  _preferences.putString("password", password);
+  _preferences.putString("token", userToken);
+  _preferences.end();
+
+  _config.ssid = ssid;
+  _config.password = password;
+  _config.userToken = userToken;
+
+  Serial.println("[WiFiManager] Configuração de Wi-Fi salva no NVS.");
+}
+
+void WiFiManager::startStation() {
+  WiFi.mode(WIFI_STA);
+  WiFi.setHostname("AgroSenseNode");
+  Serial.println("[WiFiManager] Iniciando modo Station.");
+  WiFi.begin(_config.ssid.c_str(), _config.password.c_str());
+  _lastActionMillis = millis();
+  _reconnectPending = true;
+}
+
+void WiFiManager::attemptReconnect() {
+  if (_connected || _portalStarted) {
+    return;
+  }
+
+  unsigned long now = millis();
+  if (_reconnectAttempts >= _maxReconnect) {
+    if (now - _lastActionMillis >= _reconnectResetMs) {
+      Serial.println("[WiFiManager] Reiniciando contador de tentativas.");
+      _reconnectAttempts = 0;
+      _lastActionMillis = now;
+    } else if (!_portalStarted) {
+      Serial.println("[WiFiManager] Número máximo de tentativas alcançado. Abrindo portal cautivo.");
+      startCaptivePortal();
+    }
+    return;
+  }
+
+  if (now - _lastActionMillis < _reconnectBackoffMs) {
+    return;
+  }
+
+  _reconnectAttempts++;
+  _lastActionMillis = now;
+  Serial.printf("[WiFiManager] Tentativa de reconexão %u/%u...\n", _reconnectAttempts, _maxReconnect);
+  WiFi.disconnect(true, true);
+  WiFi.begin(_config.ssid.c_str(), _config.password.c_str());
+}
+
+void WiFiManager::startCaptivePortal() {
+  if (_portalStarted) {
+    return;
+  }
+
+  Serial.println("[WiFiManager] Iniciando captive portal...");
+
+  WiFi.disconnect(true, true);
+  WiFi.mode(WIFI_AP_STA);
+  IPAddress apIP(192, 168, 4, 1);
+  WiFi.softAPConfig(apIP, apIP, IPAddress(255, 255, 255, 0));
+  WiFi.softAP("AgroSense-Setup");
+  delay(100);
+
+  _dnsServer.start(53, "*", apIP);
+  _server.begin();
+  _portalStarted = true;
+  _reconnectPending = false;
+  Serial.println("[WiFiManager] Portal cautivo ativo em: AgroSense-Setup");
+  Serial.println("[WiFiManager] Acesse qualquer URL para ver o portal de configuração.");
+}
+
+void WiFiManager::stopCaptivePortal() {
+  if (!_portalStarted) {
+    return;
+  }
+
+  Serial.println("[WiFiManager] Parando captive portal.");
+  _server.stop();
+  _dnsServer.stop();
+  WiFi.softAPdisconnect(true);
+  _portalStarted = false;
+}
+
+String WiFiManager::captivePortalPage(const String& message) const {
+  String html = "<!DOCTYPE html><html lang=\"pt-BR\">";
+  html += "<head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">";
+  html += "<title>Portal AgroSense</title>";
+  html += "<style>body{font-family:Arial,sans-serif;background:#f4f7f9;color:#222;margin:0;padding:0;}";
+  html += " .page{max-width:480px;margin:48px auto;padding:24px;background:#fff;border-radius:12px;box-shadow:0 10px 30px rgba(0,0,0,.08);} ";
+  html += " h1{margin-top:0;font-size:24px;} label{display:block;margin:12px 0 6px;font-weight:600;}";
+  html += " input[type=text], input[type=password]{width:100%;padding:10px;border:1px solid #ccd0d5;border-radius:6px;}";
+  html += " button{margin-top:18px;padding:12px 18px;background:#0078d4;color:#fff;border:none;border-radius:8px;font-size:16px;cursor:pointer;}";
+  html += " .hint{font-size:14px;color:#555;margin-top:12px;}";
+  html += " .message{background:#e8f4ff;color:#003a6d;padding:12px;border-radius:8px;margin-bottom:16px;}";
+  html += "</style></head><body><div class=\"page\">";
+  html += "<h1>Portal AgroSense</h1>";
+  html += "<p>Conecte o dispositivo à sua rede Wi-Fi e informe o token do usuário.</p>";
+  if (message.length() > 0) {
+    html += "<div class=\"message\">" + message + "</div>";
+  }
+  html += "<form method=\"POST\" action=\"/save\">";
+  html += "<label for=\"ssid\">SSID</label>";
+  html += "<input type=\"text\" id=\"ssid\" name=\"ssid\" value=\"" + _config.ssid + "\" required>";
+  html += "<label for=\"password\">Senha Wi-Fi</label>";
+  html += "<input type=\"password\" id=\"password\" name=\"password\" value=\"" + _config.password + "\" required>";
+  html += "<label for=\"token\">Token do Usuário (opcional)</label>";
+  html += "<input type=\"text\" id=\"token\" name=\"token\" value=\"" + _config.userToken + "\">";
+  html += "<button type=\"submit\">Salvar e Conectar</button>";
+  html += "</form>";
+  html += "<p class=\"hint\">Após salvar, o dispositivo irá reiniciar e tentar conectar à rede configurada.</p>";
+  html += "</div></body></html>";
+  return html;
+}
+
+void WiFiManager::handleRoot() {
+  _server.send(200, "text/html", captivePortalPage());
+}
+
+void WiFiManager::handleSave() {
+  String ssid = _server.arg("ssid");
+  String password = _server.arg("password");
+  String token = _server.arg("token");
+
+  if (ssid.length() == 0 || password.length() == 0) {
+    _server.send(400, "text/html", captivePortalPage("SSID e senha são obrigatórios."));
+    return;
+  }
+
+  saveConfig(ssid, password, token);
+  _server.send(200, "text/html", captivePortalPage("Configurações salvas com sucesso. O dispositivo reiniciará em breve."));
+  delay(2000);
+  ESP.restart();
+}
+
+void WiFiManager::handleNotFound() {
+  _server.sendHeader("Location", "/", true);
+  _server.send(302, "text/plain", "");
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,26 @@
 #include <Arduino.h>
+#include <WiFi.h>
 #include "EnvironmentSensor.h"
 
 #define LED_PIN 2
 
-// Variáveis para controlar o tempo sem travar
-unsigned long previousMillis = 0;  // Guarda o último momento que o LED piscou
-const long interval = 2000;        // Intervalo desejado (2000ms = 2 segundos)
+// Configurações de Wi-Fi
+const char* WIFI_SSID = "SEU_SSID";
+const char* WIFI_PASSWORD = "SUA_SENHA";
+const uint8_t WIFI_MAX_RECONNECT_ATTEMPTS = 5;
+const unsigned long WIFI_RECONNECT_BACKOFF_MS = 5000UL; // 5 segundos
+const unsigned long WIFI_STATUS_CHECK_MS = 5000UL;     // Checa status a cada 5 segundos
+const unsigned long WIFI_RECONNECT_RESET_MS = 60000UL;  // Reinicia tentativas após 60 segundos
+
+// Variáveis de controle de tempo
+unsigned long previousMillis = 0;
+unsigned long wifiLastActionMillis = 0;
+unsigned long wifiLastStatusMillis = 0;
+
+// Estado de conexão Wi-Fi
+bool wifiConnected = false;
+uint8_t wifiReconnectAttempts = 0;
+bool wifiReconnectPending = false;
 
 // Estado atual do LED
 int ledState = LOW;
@@ -13,18 +28,115 @@ int ledState = LOW;
 // Sensor DHT11 no GPIO4
 EnvironmentSensor environmentSensor(4, DHT11);
 
+void logWiFiEvent(const char* message) {
+  Serial.printf("[WiFi] %s\n", message);
+}
+
+void printWiFiStatus() {
+  wl_status_t status = WiFi.status();
+  Serial.printf("[WiFi] status atual: %d (%s)\n", status,
+                status == WL_CONNECTED ? "CONNECTED" : "DISCONNECTED");
+
+  if (status == WL_CONNECTED) {
+    Serial.printf("[WiFi] IP: %s\n", WiFi.localIP().toString().c_str());
+    Serial.printf("[WiFi] SSID: %s\n", WiFi.SSID().c_str());
+    Serial.printf("[WiFi] RSSI: %d dBm\n", WiFi.RSSI());
+  }
+}
+
+void onWiFiEvent(WiFiEvent_t event) {
+  switch (event) {
+    case SYSTEM_EVENT_STA_START:
+      logWiFiEvent("Station iniciado.");
+      break;
+    case SYSTEM_EVENT_STA_CONNECTED:
+      logWiFiEvent("Conectado ao AP.");
+      break;
+    case SYSTEM_EVENT_STA_GOT_IP:
+      wifiConnected = true;
+      wifiReconnectAttempts = 0;
+      wifiReconnectPending = false;
+      Serial.printf("[WiFi] IP obtido: %s\n", WiFi.localIP().toString().c_str());
+      break;
+    case SYSTEM_EVENT_STA_DISCONNECTED:
+      wifiConnected = false;
+      wifiReconnectPending = true;
+      Serial.printf("[WiFi] Desconectado do AP. Tentativas: %u/%u\n",
+                    wifiReconnectAttempts, WIFI_MAX_RECONNECT_ATTEMPTS);
+      break;
+    default:
+      Serial.printf("[WiFi] Evento: %u\n", event);
+      break;
+  }
+}
+
+void startWiFiStation() {
+  WiFi.mode(WIFI_STA);
+  WiFi.setHostname("AgroSenseNode");
+  WiFi.onEvent(onWiFiEvent);
+  logWiFiEvent("Iniciando modo Station.");
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  wifiLastActionMillis = millis();
+  wifiReconnectPending = true;
+}
+
+void attemptWiFiReconnect() {
+  if (wifiConnected) {
+    return;
+  }
+
+  unsigned long now = millis();
+
+  if (wifiReconnectAttempts >= WIFI_MAX_RECONNECT_ATTEMPTS) {
+    if (now - wifiLastActionMillis >= WIFI_RECONNECT_RESET_MS) {
+      Serial.println("[WiFi] Reiniciando contagem de tentativas de reconexão.");
+      wifiReconnectAttempts = 0;
+      wifiLastActionMillis = now;
+    } else {
+      return;
+    }
+  }
+
+  if (now - wifiLastActionMillis < WIFI_RECONNECT_BACKOFF_MS) {
+    return;
+  }
+
+  wifiReconnectAttempts++;
+  wifiLastActionMillis = now;
+  Serial.printf("[WiFi] Tentativa de reconexão %u/%u...\n",
+                wifiReconnectAttempts, WIFI_MAX_RECONNECT_ATTEMPTS);
+  WiFi.disconnect(true, true);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+}
+
+void monitorWiFi() {
+  unsigned long now = millis();
+
+  if (wifiReconnectPending) {
+    attemptWiFiReconnect();
+  }
+
+  if (now - wifiLastStatusMillis >= WIFI_STATUS_CHECK_MS) {
+    wifiLastStatusMillis = now;
+    printWiFiStatus();
+  }
+}
+
 void setup() {
   Serial.begin(115200);
   pinMode(LED_PIN, OUTPUT);
   environmentSensor.begin();
   Serial.println("AgroSense Node-Six: Boot Inicializado! 🚀");
+  startWiFiStation();
 }
 
 void loop() {
   unsigned long currentMillis = millis();
 
+  monitorWiFi();
+
   // Pisca LED sem bloquear
-  if (currentMillis - previousMillis >= interval) {
+  if (currentMillis - previousMillis >= 2000UL) {
     previousMillis = currentMillis;
     ledState = (ledState == LOW ? HIGH : LOW);
     digitalWrite(LED_PIN, ledState);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,141 +1,26 @@
 #include <Arduino.h>
-#include <WiFi.h>
+#include "WiFiManager.h"
 #include "EnvironmentSensor.h"
 
 #define LED_PIN 2
 
-// Configurações de Wi-Fi
-const char* WIFI_SSID = "SEU_SSID";
-const char* WIFI_PASSWORD = "SUA_SENHA";
-const uint8_t WIFI_MAX_RECONNECT_ATTEMPTS = 5;
-const unsigned long WIFI_RECONNECT_BACKOFF_MS = 5000UL; // 5 segundos
-const unsigned long WIFI_STATUS_CHECK_MS = 5000UL;     // Checa status a cada 5 segundos
-const unsigned long WIFI_RECONNECT_RESET_MS = 60000UL;  // Reinicia tentativas após 60 segundos
-
-// Variáveis de controle de tempo
 unsigned long previousMillis = 0;
-unsigned long wifiLastActionMillis = 0;
-unsigned long wifiLastStatusMillis = 0;
-
-// Estado de conexão Wi-Fi
-bool wifiConnected = false;
-uint8_t wifiReconnectAttempts = 0;
-bool wifiReconnectPending = false;
-
-// Estado atual do LED
 int ledState = LOW;
-
-// Sensor DHT11 no GPIO4
 EnvironmentSensor environmentSensor(4, DHT11);
-
-void logWiFiEvent(const char* message) {
-  Serial.printf("[WiFi] %s\n", message);
-}
-
-void printWiFiStatus() {
-  wl_status_t status = WiFi.status();
-  Serial.printf("[WiFi] status atual: %d (%s)\n", status,
-                status == WL_CONNECTED ? "CONNECTED" : "DISCONNECTED");
-
-  if (status == WL_CONNECTED) {
-    Serial.printf("[WiFi] IP: %s\n", WiFi.localIP().toString().c_str());
-    Serial.printf("[WiFi] SSID: %s\n", WiFi.SSID().c_str());
-    Serial.printf("[WiFi] RSSI: %d dBm\n", WiFi.RSSI());
-  }
-}
-
-void onWiFiEvent(WiFiEvent_t event) {
-  switch (event) {
-    case SYSTEM_EVENT_STA_START:
-      logWiFiEvent("Station iniciado.");
-      break;
-    case SYSTEM_EVENT_STA_CONNECTED:
-      logWiFiEvent("Conectado ao AP.");
-      break;
-    case SYSTEM_EVENT_STA_GOT_IP:
-      wifiConnected = true;
-      wifiReconnectAttempts = 0;
-      wifiReconnectPending = false;
-      Serial.printf("[WiFi] IP obtido: %s\n", WiFi.localIP().toString().c_str());
-      break;
-    case SYSTEM_EVENT_STA_DISCONNECTED:
-      wifiConnected = false;
-      wifiReconnectPending = true;
-      Serial.printf("[WiFi] Desconectado do AP. Tentativas: %u/%u\n",
-                    wifiReconnectAttempts, WIFI_MAX_RECONNECT_ATTEMPTS);
-      break;
-    default:
-      Serial.printf("[WiFi] Evento: %u\n", event);
-      break;
-  }
-}
-
-void startWiFiStation() {
-  WiFi.mode(WIFI_STA);
-  WiFi.setHostname("AgroSenseNode");
-  WiFi.onEvent(onWiFiEvent);
-  logWiFiEvent("Iniciando modo Station.");
-  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
-  wifiLastActionMillis = millis();
-  wifiReconnectPending = true;
-}
-
-void attemptWiFiReconnect() {
-  if (wifiConnected) {
-    return;
-  }
-
-  unsigned long now = millis();
-
-  if (wifiReconnectAttempts >= WIFI_MAX_RECONNECT_ATTEMPTS) {
-    if (now - wifiLastActionMillis >= WIFI_RECONNECT_RESET_MS) {
-      Serial.println("[WiFi] Reiniciando contagem de tentativas de reconexão.");
-      wifiReconnectAttempts = 0;
-      wifiLastActionMillis = now;
-    } else {
-      return;
-    }
-  }
-
-  if (now - wifiLastActionMillis < WIFI_RECONNECT_BACKOFF_MS) {
-    return;
-  }
-
-  wifiReconnectAttempts++;
-  wifiLastActionMillis = now;
-  Serial.printf("[WiFi] Tentativa de reconexão %u/%u...\n",
-                wifiReconnectAttempts, WIFI_MAX_RECONNECT_ATTEMPTS);
-  WiFi.disconnect(true, true);
-  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
-}
-
-void monitorWiFi() {
-  unsigned long now = millis();
-
-  if (wifiReconnectPending) {
-    attemptWiFiReconnect();
-  }
-
-  if (now - wifiLastStatusMillis >= WIFI_STATUS_CHECK_MS) {
-    wifiLastStatusMillis = now;
-    printWiFiStatus();
-  }
-}
+WiFiManager wifiManager;
 
 void setup() {
   Serial.begin(115200);
   pinMode(LED_PIN, OUTPUT);
   environmentSensor.begin();
   Serial.println("AgroSense Node-Six: Boot Inicializado! 🚀");
-  startWiFiStation();
+  wifiManager.begin();
 }
 
 void loop() {
   unsigned long currentMillis = millis();
+  wifiManager.loop();
 
-  monitorWiFi();
-
-  // Pisca LED sem bloquear
   if (currentMillis - previousMillis >= 2000UL) {
     previousMillis = currentMillis;
     ledState = (ledState == LOW ? HIGH : LOW);
@@ -143,7 +28,6 @@ void loop() {
     Serial.print("LED ");
     Serial.println(ledState == HIGH ? "ON" : "OFF");
 
-    // Lê dados do sensor ambiente
     EnvironmentSensor::EnvData reading = environmentSensor.readData();
     if (reading.valid) {
       Serial.print("Temperatura: ");


### PR DESCRIPTION
### **Conexão Wi-Fi robusta**

- main.cpp: refatorei o setup() e o loop() para usar um gerenciador de Wi-Fi dedicado.

- WifiManager passou a controlar:

Inicialização em modo Station ( WIFI_STA )
Detecção de queda de conexão via eventos do sistema
Tentativas de reconexão com limite configurável
Backoff entre tentativas para não travar o firmware
Logs detalhados no Serial (CONNECTED, DISCONNECTED, IP, RSSI, tentativas)

- O loop principal continua não bloqueante, mantendo o LED piscando e a leitura do sensor DHT11 rodando normalmente.

---
### **Portal cautivo (Wi-Fi Manager)**

- Adicionei WifiManager.h  e WifiManager.cpp
- O ESP32 entra em modo AP se não encontrar credenciais salvas ou se não conseguir conectar após várias tentativas.
- O AP criado é AgroSense-Setup e o DNS redirect garante que qualquer URL abra o portal de configuração.
- O portal fornece uma página HTML para:
Inserir SSID
Inserir senha Wi-Fi
Informar token de usuário opcional
- As credenciais e o token são salvos em memória não volátil usando Preferences (NVS) e o dispositivo reinicia após salvar para conectar na rede configurada.
- --
### **Objetivo único**

Implementar um sistema de rede para o ESP32 que mantenha o dispositivo conectado automaticamente ao Wi-Fi, reconecte com tentativas limitadas e backoff, e forneça um portal cautivo para configurar SSID, senha e token do usuário sem hardcode.

**Resultado**
Sim — a implementação foi feita e compilou com sucesso, incluindo:

- Modo Station com reconexão automática,
- Backoff entre tentativas,
- Portal cautivo AP AgroSense-Setup,
- Formulário de configuração,
- Salvamento persistente em NVS.